### PR TITLE
Fix/issue63

### DIFF
--- a/at.o2xfs.xfs.service/src/main/java/at/o2xfs/xfs/service/idc/cmd/IDCStatusCommand.java
+++ b/at.o2xfs.xfs.service/src/main/java/at/o2xfs/xfs/service/idc/cmd/IDCStatusCommand.java
@@ -33,12 +33,12 @@ import at.o2xfs.log.Logger;
 import at.o2xfs.log.LoggerFactory;
 import at.o2xfs.xfs.WFSResult;
 import at.o2xfs.xfs.XfsException;
-import at.o2xfs.xfs.cim.CimInfoCommand;
-import at.o2xfs.xfs.v3_00.idc.Status3;
+import at.o2xfs.xfs.idc.IdcInfoCommand;
 import at.o2xfs.xfs.service.XfsServiceManager;
 import at.o2xfs.xfs.service.cmd.XfsInfoCommand;
 import at.o2xfs.xfs.service.idc.IDCService;
 import at.o2xfs.xfs.service.idc.IdcFactory;
+import at.o2xfs.xfs.v3_00.idc.Status3;
 
 /**
  * This command reports the full range of information available, including the
@@ -63,7 +63,7 @@ public class IDCStatusCommand implements Callable<Status3> {
 	@Override
 	public Status3 call() throws XfsException {
 		Status3 result;
-		XfsInfoCommand<CimInfoCommand> command = new XfsInfoCommand<CimInfoCommand>(idcService, CimInfoCommand.STATUS);
+		XfsInfoCommand<IdcInfoCommand> command = new XfsInfoCommand<IdcInfoCommand>(idcService, IdcInfoCommand.STATUS);
 		WFSResult wfsResult = null;
 		try {
 			wfsResult = command.call();

--- a/at.o2xfs.xfs/src/main/java/at/o2xfs/xfs/conf/O2XfsConf.java
+++ b/at.o2xfs.xfs/src/main/java/at/o2xfs/xfs/conf/O2XfsConf.java
@@ -154,7 +154,7 @@ public final class O2XfsConf {
 	 */
 	public String wfmQueryValue(final HKEY hKey, final String valueName) throws XfsException {
 		final ZSTR data = new ZSTR(SIZE_LIMIT, true);
-		final DWORD cchData = new DWORD(0L);
+		final DWORD cchData = new DWORD(data.getSize());
 		final int errorCode = wfmQueryValue0(hKey, new ZSTR(valueName), data, cchData);
 		XfsException.throwFor(errorCode);
 		return data.toString();


### PR DESCRIPTION
As @VitalyEG pointed out, `lpcchData` must contain the size of the buffer pointed to by `cchData` or `CFG_VALUE_TOO_LONG` error occurs.